### PR TITLE
Tab resizing

### DIFF
--- a/app.R
+++ b/app.R
@@ -80,7 +80,7 @@ ui <-
                    tags$h4(class="map-title", "COVID-19 Mortality Rate Disparities by State Compared to Average US Rate"),
                            leafletOutput(outputId = "map.covid_deaths", height="100%"), width=8)
                ), 
-               tags$script(src = "style.js")
+               #tags$script(src = "style.js")
       ), 
       tabPanel(tags$div(class="tab-title",style="text-align:center;", #For some reason, unresponsive to class
                         HTML("<div style='font-size:80%;line-height:1.3;'><b>OUTCOME (USA)</b></br>Racial/Ethnic Disparity</div>")),
@@ -131,7 +131,6 @@ ui <-
                                selected = "nhbaa")),
                    leafletOutput(outputId = "map.covid_deaths.race", height="95%"), width=8)
                ), 
-               tags$script(src = "style.js")
       ), 
       tabPanel(tags$div(class="tab-title",style="text-align:center;",
                         HTML("<div style='font-size:80%;line-height:1.3;'><b>OUTCOME (NY)</b></br>Mortality Rate</div>")),
@@ -164,7 +163,7 @@ ui <-
                  
                  mainPanel(id = "mainpanel_ny_mort",
                            tags$h4(class="map-title", "COVID-19 Mortality Rate Disparities by County in New York Compared to Average US Rate"),
-                           leafletOutput(outputId = "map.NY.deaths", height="100%"), width=8)
+                           leafletOutput(outputId = "map.NY.deaths", height = "100%"), width=8)
                    )
                  ),
       tabPanel(tags$div(class="tab-title",style="text-align:center;",
@@ -551,7 +550,8 @@ ui <-
                )
       )
       )
-    )
+    ), 
+    tags$script(src = "style.js")
   )
 #### Server Code ####
 server <- function(input, output, session) {

--- a/www/style.js
+++ b/www/style.js
@@ -51,4 +51,5 @@ function resize_plot() {
 
 window.addEventListener("resize", resize_plot);
 window.addEventListener("click", resize_plot);
+window.addEventListener("scroll", resize_plot);
 resize_plot();

--- a/www/style.js
+++ b/www/style.js
@@ -16,18 +16,39 @@ var ids = {
   "sidebar_ct_race": "#mainpanel_ct_race"
 };
 
+var ids2 = {
+  "sidebar_us_mort": "mainpanel_us_mort",
+  "sidebar_us_test": "mainpanel_us_test",
+  "sidebar_us_hosp": "mainpanel_us_hosp",
+  "sidebar_us_db": "mainpanel_us_db",
+  "sidebar_us_cardio": "mainpanel_us_cardio",
+  "sidebar_ny_mort": "mainpanel_ny_mort",
+  "sidebar_ny_cases": "mainpanel_ny_cases",
+  "sidebar_ny_CoT": "mainpanel_ny_CoT", 
+  "sidebar_ny_det": "mainpanel_ny_det", 
+  "sidebar_ny_CoT_rates": "mainpanel_ny_CoT_rates", 
+  "sidebar_ny_race": "mainpanel_ny_race", 
+  "sidebar_us_mort_race": "mainpanel_us_mort_race", 
+  "sidebar_ct_race": "mainpanel_ct_race"
+};
+
+var maps = {
+  "sidebar_ny_mort": "#map.NY.deaths"
+};
+
 function resize_plot() {
   for (var key in ids) {
+  var sidebar0 = document.getElementById("sidebar_us_mort");
   var sidebar1 = document.getElementById(key);
   if(sidebar1) {
-    var positionInfo = sidebar1.getBoundingClientRect();
-    var height = positionInfo.height;
+    var positionInfo0 = sidebar0.getBoundingClientRect();
+    var positionInfo1 = sidebar1.getBoundingClientRect();
+    var height = Math.max(positionInfo0.height,positionInfo1.height)
     $(ids[key]).height(height);
   }
   }
 }
 
-//$("#mainPanel_us_mort").on("resize", resize_plot);
 window.addEventListener("resize", resize_plot);
 window.addEventListener("click", resize_plot);
 resize_plot();


### PR DESCRIPTION
This update goes alongside Issue #271. Resize javascript file now selects first page for initial plot sizing, allowing for the plot to appear when you jump to covidminder from a specific tab. Ideally this would resize to the exact height as the respective sidebar, but on map load only the first tab is defined.