### PR TITLE
Add county selection functionality

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -70,6 +70,7 @@
 
 .form-group{
   margin-bottom:0;
+  float:left;
 }
 
 .select-bar {
@@ -107,3 +108,8 @@
   }
 }
 
+@media screen and (max-width:925px){
+  .NY_case_plots {
+  height: Calc(90% - 140px);
+}
+}


### PR DESCRIPTION
Adds a second selection tool to select individual counties as well as full regions in NY Cases/Case rate tabs. 